### PR TITLE
Load project listings from JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# OngCDH-research-site
-Site for testing CDH research outputs
+# OngCDH Research Site
+
+Static marketing and repository landing page for the Walter J. Ong, S.J. Center for Digital Humanities at Saint Louis University.
+
+## Getting started
+
+1. Open `index.html` in your browser to view the site locally. No build step is required.
+2. All styles live in `assets/css/main.css` and client-side behavior in `assets/js/app.js`.
+3. Featured projects are loaded from JSON files inside `assets/data/projects`. Drop new JSON files in that directory to publish additional work.
+
+### Adding a project
+
+1. Copy one of the existing files in `assets/data/projects` (for example `project-04.json`).
+2. Rename the copy using the `project-XX.json` pattern. Increment `XX` with the next available number (e.g., `project-05.json`).
+3. Update the JSON fields:
+   - `title`: Project name displayed on the card.
+   - `description`: Short summary of the work.
+   - `type`: One of `faculty`, `student`, or `community` for filtering.
+   - `team`: People or units involved.
+   - `year`: Launch year or most recent major update.
+   - `link`: URL to the live project or repository.
+   - `tags`: Array of keywords.
+4. Save the file. No JavaScript changes are needed—the page automatically loads all numbered project files.
+
+White papers can be listed by updating the `WHITE_PAPERS` array in `assets/js/app.js` when documents are ready to share.
+
+## Brand alignment
+
+- Color palette follows SLU brand guidance (SLU Blue, deep navy, neutral grays, accent red).
+- Typeface pairing uses Montserrat and Source Serif as accessible web alternatives to SLU&rsquo;s Proxima Nova and Mercury families.
+- Custom SVG shield and geometric background evoke university identity without relying on WordPress themes.
+
+## Accessibility & responsiveness
+
+- Semantic HTML structure with landmark elements and accessible navigation controls.
+- Responsive layout using CSS grid/flexbox and mobile navigation toggle.
+- Searchable white paper list and filterable project grid for quick discovery.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,780 @@
+:root {
+  --slu-blue: #005daa;
+  --slu-blue-dark: #003a70;
+  --slu-gray: #5b6770;
+  --slu-gray-light: #eef2f6;
+  --slu-accent: #c8102e;
+  --white: #ffffff;
+  --max-width: 1120px;
+  --radius: 16px;
+  --shadow-soft: 0 20px 45px rgba(0, 40, 85, 0.12);
+  --shadow-card: 0 14px 40px rgba(0, 61, 125, 0.16);
+  --transition: all 0.25s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: 'Montserrat', 'Segoe UI', Roboto, sans-serif;
+  color: #12263a;
+  background-color: var(--white);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover,
+a:focus {
+  color: var(--slu-blue);
+}
+
+.container {
+  width: min(100% - 3rem, var(--max-width));
+  margin-inline: auto;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(0, 61, 125, 0.08);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding-block: 1rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  text-transform: uppercase;
+}
+
+.brand__mark {
+  width: 52px;
+  height: auto;
+}
+
+.brand__label {
+  font-size: 0.68rem;
+  letter-spacing: 0.15em;
+  color: var(--slu-gray);
+}
+
+.brand__unit {
+  display: block;
+  font-weight: 600;
+  color: var(--slu-blue-dark);
+  letter-spacing: 0.06em;
+}
+
+.site-nav {
+  position: relative;
+}
+
+.site-nav__list {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.site-nav__list a {
+  text-decoration: none;
+  padding-bottom: 0.25rem;
+  border-bottom: 2px solid transparent;
+  transition: var(--transition);
+}
+
+.site-nav__list a:hover,
+.site-nav__list a:focus {
+  color: var(--slu-blue);
+  border-color: var(--slu-blue);
+}
+
+.site-nav__toggle {
+  display: none;
+  flex-direction: column;
+  gap: 0.3rem;
+  width: 2.5rem;
+  background: none;
+  border: 0;
+  padding: 0.25rem;
+}
+
+.site-nav__toggle span {
+  height: 3px;
+  background-color: var(--slu-blue-dark);
+  border-radius: 999px;
+  transition: var(--transition);
+}
+
+.hero {
+  position: relative;
+  color: var(--white);
+  background: radial-gradient(circle at 10% 20%, rgba(0, 93, 170, 0.8), rgba(0, 58, 112, 0.95)),
+    url('../images/pattern.svg');
+  background-size: cover;
+  padding: clamp(4rem, 10vw, 7rem) 0;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(130deg, rgba(0, 61, 125, 0.75) 0%, rgba(0, 93, 170, 0.9) 45%, rgba(0, 44, 85, 0.88) 100%);
+  mix-blend-mode: multiply;
+}
+
+.hero__content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: end;
+}
+
+.hero__text h1 {
+  font-family: 'Source Serif 4', 'Georgia', serif;
+  font-size: clamp(2.5rem, 5vw, 3.4rem);
+  margin-bottom: 1rem;
+}
+
+.hero__text p {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  max-width: 34rem;
+}
+
+.eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 1.5rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2.5rem;
+}
+
+.hero__panel {
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(18px);
+  padding: 2rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.hero__panel-title {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hero__panel-text {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.6;
+}
+
+.hero__highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.hero__highlights li {
+  color: rgba(255, 255, 255, 0.9);
+  line-height: 1.6;
+}
+
+.hero__highlights span {
+  font-weight: 600;
+  color: var(--white);
+}
+
+.section {
+  padding: clamp(4rem, 8vw, 6rem) 0;
+}
+
+.section--light {
+  background-color: var(--slu-gray-light);
+}
+
+.section--accent {
+  background: linear-gradient(135deg, rgba(0, 93, 170, 0.95), rgba(0, 58, 112, 0.92));
+  color: var(--white);
+}
+
+.section__header {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: clamp(2rem, 6vw, 3rem);
+}
+
+.section__header p {
+  color: inherit;
+  max-width: 48rem;
+}
+
+.section__header--split {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: end;
+  gap: 2rem;
+}
+
+.section__header--cta {
+  align-items: center;
+}
+
+.lead {
+  font-size: 1.1rem;
+  color: var(--slu-gray);
+  line-height: 1.7;
+}
+
+.section__grid {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.section__grid--legacy {
+  align-items: start;
+}
+
+.legacy-highlight {
+  position: relative;
+  overflow: hidden;
+}
+
+.legacy-highlight::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(0, 61, 125, 0.08), rgba(0, 133, 202, 0.08));
+  z-index: 0;
+}
+
+.legacy-highlight > * {
+  position: relative;
+  z-index: 1;
+}
+
+.section__grid--resources {
+  align-items: start;
+}
+
+.card-stack {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  background-color: var(--white);
+  padding: 1.75rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-card);
+  border: 1px solid rgba(0, 61, 125, 0.08);
+}
+
+.card h3 {
+  margin-top: 0;
+  font-size: 1.2rem;
+  color: var(--slu-blue-dark);
+}
+
+.people-groups {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.people-group {
+  background: var(--white);
+  border-radius: var(--radius);
+  border: 1px solid rgba(0, 61, 125, 0.08);
+  box-shadow: var(--shadow-card);
+  padding: 1.75rem;
+  color: var(--slu-gray);
+}
+
+.people-group h3 {
+  color: var(--slu-blue-dark);
+  margin-top: 0;
+}
+
+.affiliates-list {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.affiliates-list article {
+  background: var(--white);
+  border-radius: var(--radius);
+  border: 1px solid rgba(0, 61, 125, 0.08);
+  box-shadow: var(--shadow-card);
+  padding: 1.75rem;
+  color: var(--slu-gray);
+}
+
+.affiliates-list h3 {
+  color: var(--slu-blue-dark);
+  margin-top: 0;
+}
+
+.affiliates-list ul {
+  margin: 1rem 0 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.affiliates-list li {
+  line-height: 1.6;
+}
+
+.impact-highlights {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.impact-card {
+  padding: 1.75rem;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: var(--shadow-soft);
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.7;
+}
+
+.impact-card h3 {
+  margin: 0 0 0.75rem;
+  color: var(--white);
+}
+
+.filters {
+  display: inline-flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.filter-button {
+  border: 1px solid rgba(0, 61, 125, 0.2);
+  border-radius: 999px;
+  background-color: var(--white);
+  color: var(--slu-blue-dark);
+  font-weight: 600;
+  padding: 0.5rem 1.4rem;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.filter-button.is-active,
+.filter-button:hover {
+  background-color: var(--slu-blue);
+  color: var(--white);
+  border-color: transparent;
+}
+
+.project-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.project-card {
+  position: relative;
+  background-color: var(--white);
+  border-radius: var(--radius);
+  padding: 2.25rem;
+  box-shadow: var(--shadow-card);
+  border: 1px solid rgba(0, 61, 125, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.project-card__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--slu-blue-dark);
+  opacity: 0.7;
+}
+
+.project-card h3 {
+  font-family: 'Source Serif 4', 'Georgia', serif;
+  font-size: 1.45rem;
+  color: var(--slu-blue-dark);
+  margin: 0;
+}
+
+.project-card p {
+  margin: 0;
+  color: var(--slu-gray);
+  line-height: 1.7;
+}
+
+.project-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--slu-gray);
+}
+
+.project-card__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--slu-blue);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.project-card__link::after {
+  content: '→';
+  font-size: 1.2rem;
+  transition: transform 0.2s ease;
+}
+
+.project-card__link:hover::after,
+.project-card__link:focus::after {
+  transform: translateX(4px);
+}
+
+.white-paper-list {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.white-paper {
+  display: grid;
+  gap: 0.6rem;
+  padding: 1.75rem;
+  border-radius: var(--radius);
+  background-color: var(--white);
+  border: 1px solid rgba(0, 61, 125, 0.08);
+  box-shadow: var(--shadow-soft);
+}
+
+.white-paper h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--slu-blue-dark);
+}
+
+.white-paper__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: var(--slu-gray);
+}
+
+.white-paper__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.white-paper__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--slu-blue);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.white-paper__link::before {
+  content: '\1F4C4';
+}
+
+.search {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.search__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--slu-gray);
+}
+
+.search__input {
+  border-radius: 999px;
+  border: 1px solid rgba(0, 61, 125, 0.16);
+  padding: 0.75rem 1.25rem;
+  font-size: 1rem;
+  transition: var(--transition);
+}
+
+.search__input:focus {
+  outline: 2px solid rgba(0, 93, 170, 0.25);
+  border-color: var(--slu-blue);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.75rem;
+  font-weight: 600;
+  border-radius: 999px;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: var(--transition);
+  letter-spacing: 0.05em;
+}
+
+.button--primary {
+  background-color: var(--slu-blue);
+  color: var(--white);
+}
+
+.button--primary:hover,
+.button--primary:focus {
+  background-color: var(--slu-blue-dark);
+}
+
+.button--ghost {
+  background-color: rgba(255, 255, 255, 0.16);
+  color: var(--white);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+}
+
+.button--ghost:hover,
+.button--ghost:focus {
+  background-color: rgba(255, 255, 255, 0.28);
+}
+
+.button--inverse {
+  background-color: var(--white);
+  color: var(--slu-blue-dark);
+}
+
+.button--inverse:hover,
+.button--inverse:focus {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.resource-card {
+  background: linear-gradient(135deg, rgba(0, 93, 170, 0.18), rgba(0, 58, 112, 0.4));
+  border-radius: var(--radius);
+  padding: 2rem;
+  box-shadow: var(--shadow-card);
+  color: var(--slu-blue-dark);
+  border: 1px solid rgba(0, 61, 125, 0.1);
+}
+
+.resource-card__note {
+  font-size: 0.9rem;
+  color: var(--slu-gray);
+}
+
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.checklist li {
+  position: relative;
+  padding-left: 1.75rem;
+  line-height: 1.6;
+  color: var(--slu-gray);
+}
+
+.checklist li::before {
+  content: '\2713';
+  position: absolute;
+  left: 0;
+  top: 0.1rem;
+  color: var(--slu-blue);
+  font-weight: 700;
+}
+
+.section--cta {
+  text-align: center;
+}
+
+.site-footer {
+  background-color: #0a1d33;
+  color: rgba(255, 255, 255, 0.9);
+  padding: clamp(3rem, 7vw, 4rem) 0;
+}
+
+.site-footer__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.site-footer__title {
+  margin-top: 0;
+  font-size: 1.4rem;
+}
+
+.site-footer a {
+  color: rgba(255, 255, 255, 0.9);
+  text-decoration: none;
+}
+
+.site-footer a:hover,
+.site-footer a:focus {
+  color: var(--white);
+}
+
+.form {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.form input {
+  border-radius: 999px;
+  border: none;
+  padding: 0.75rem 1.25rem;
+  font-size: 1rem;
+}
+
+.form__confirmation {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.contact-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.social-links {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.footer-note {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+@media (max-width: 840px) {
+  .site-nav__toggle {
+    display: flex;
+  }
+
+  .site-nav__list {
+    position: absolute;
+    inset: calc(100% + 0.5rem) 0 auto auto;
+    background-color: var(--white);
+    border-radius: var(--radius);
+    padding: 1.25rem;
+    flex-direction: column;
+    gap: 1rem;
+    box-shadow: var(--shadow-soft);
+    border: 1px solid rgba(0, 61, 125, 0.12);
+    transform-origin: top right;
+    transform: scale(0.9);
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .site-nav__list.is-open {
+    transform: scale(1);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .form {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 540px) {
+  .container {
+    width: min(100% - 2rem, var(--max-width));
+  }
+
+  .hero__text h1 {
+    font-size: clamp(2.2rem, 7vw, 2.8rem);
+  }
+
+  .section__header--split {
+    grid-template-columns: 1fr;
+  }
+
+  .hero__panel {
+    padding: 1.5rem;
+  }
+}

--- a/assets/data/projects/project-01.json
+++ b/assets/data/projects/project-01.json
@@ -1,0 +1,9 @@
+{
+  "title": "Rerum.io",
+  "description": "An open, collaboratively maintained linked data repository that gives digital humanities projects a durable platform for sharing annotations and scholarly datasets.",
+  "type": "faculty",
+  "team": "Walter J. Ong, S.J. Center for Digital Humanities with partner institutions",
+  "year": 2014,
+  "link": "https://rerum.io/",
+  "tags": ["Linked data", "APIs", "Interoperability"]
+}

--- a/assets/data/projects/project-02.json
+++ b/assets/data/projects/project-02.json
@@ -1,0 +1,9 @@
+{
+  "title": "T-PEN (Transcription for Paleographical and Editorial Notation)",
+  "description": "A browser-based transcription environment that supports collaborative encoding of manuscripts with IIIF imagery, TEI export, and project management tools.",
+  "type": "faculty",
+  "team": "Saint Louis University Center for Digital Humanities development team",
+  "year": 2011,
+  "link": "https://t-pen.org/TPEN/",
+  "tags": ["Manuscripts", "Transcription", "IIIF"]
+}

--- a/assets/data/projects/project-03.json
+++ b/assets/data/projects/project-03.json
@@ -1,0 +1,9 @@
+{
+  "title": "Sounding Tennyson",
+  "description": "A multimedia edition that pairs Alfred Tennyson's poetry with new audio performances, contextual essays, and classroom resources produced with student scholars.",
+  "type": "student",
+  "team": "Faculty and student researchers in English and Music at Saint Louis University",
+  "year": 2016,
+  "link": "https://soundingtennyson.org/",
+  "tags": ["Digital edition", "Audio", "Pedagogy"]
+}

--- a/assets/data/projects/project-04.json
+++ b/assets/data/projects/project-04.json
@@ -1,0 +1,9 @@
+{
+  "title": "Broken Books",
+  "description": "Digital reconstructions of manuscripts dispersed by the 1849 College Saint Nicholas fire, combining IIIF images, metadata, and scholarship on provenance.",
+  "type": "faculty",
+  "team": "Walter J. Ong, S.J. Center for Digital Humanities with university and archival partners",
+  "year": 2019,
+  "link": "https://brokenbooks.slu.edu/",
+  "tags": ["IIIF", "Restoration", "Provenance"]
+}

--- a/assets/images/pattern.svg
+++ b/assets/images/pattern.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f3d78" />
+      <stop offset="100%" stop-color="#012452" />
+    </linearGradient>
+    <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+      <path d="M0 60V0h60" fill="none" stroke="#1d5fbf" stroke-width="1" opacity="0.25" />
+      <path d="M0 30h60M30 0v60" fill="none" stroke="#1d5fbf" stroke-width="0.5" opacity="0.15" />
+    </pattern>
+    <pattern id="diamonds" width="120" height="120" patternUnits="userSpaceOnUse">
+      <path
+        d="M60 10l40 50-40 50-40-50z"
+        fill="none"
+        stroke="#5fa0ff"
+        stroke-width="1.6"
+        opacity="0.18"
+      />
+    </pattern>
+  </defs>
+  <rect width="600" height="600" fill="url(#bg)" />
+  <rect width="600" height="600" fill="url(#grid)" />
+  <rect width="600" height="600" fill="url(#diamonds)" />
+</svg>

--- a/assets/images/slu-shield.svg
+++ b/assets/images/slu-shield.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 160" role="img" aria-labelledby="title desc">
+  <title id="title">Stylized Saint Louis University Shield</title>
+  <desc id="desc">A simplified blue shield with a white fleur-de-lis inspired emblem.</desc>
+  <defs>
+    <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a6ec2" />
+      <stop offset="100%" stop-color="#003a70" />
+    </linearGradient>
+  </defs>
+  <path
+    d="M60 4c24 0 52 6 52 6v60c0 37-27 66-52 86-25-20-52-49-52-86V10s28-6 52-6z"
+    fill="url(#shieldGradient)"
+    stroke="#ffffff"
+    stroke-width="4"
+  />
+  <path
+    d="M60 32c-13 0-24 10-24 24 0 11 7 20 18 23l-6 29 12-10 12 10-6-29c11-3 18-12 18-23 0-14-11-24-24-24zm0 16c4 0 8 3 8 8s-4 8-8 8-8-3-8-8 4-8 8-8z"
+    fill="#ffffff"
+  />
+  <circle cx="60" cy="34" r="6" fill="#ffffff" opacity="0.8" />
+  <circle cx="60" cy="118" r="6" fill="#ffffff" opacity="0.7" />
+</svg>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,210 @@
+const PROJECT_DATA_DIRECTORY = 'assets/data/projects/';
+const PROJECT_FILENAME_PREFIX = 'project-';
+const PROJECT_FILENAME_EXTENSION = '.json';
+const PROJECT_MAX_INDEX = 200;
+const PROJECT_MAX_MISSES = 5;
+
+const WHITE_PAPERS = [];
+
+let projectData = [];
+let activeProjectFilter = 'all';
+
+const projectGrid = document.getElementById('project-grid');
+const filterButtons = document.querySelectorAll('.filter-button');
+const whitePaperList = document.getElementById('white-paper-list');
+const whitePaperSearch = document.getElementById('white-paper-search');
+const navToggle = document.querySelector('.site-nav__toggle');
+const navList = document.querySelector('.site-nav__list');
+
+function createProjectCard(project) {
+  const article = document.createElement('article');
+  article.className = 'project-card';
+  const tags = Array.isArray(project.tags) ? project.tags : [];
+  article.innerHTML = `
+    <span class="project-card__tag">${project.type}</span>
+    <h3>${project.title}</h3>
+    <p>${project.description}</p>
+    <div class="project-card__meta">
+      <span>${project.team}</span>
+      <span>Year: ${project.year}</span>
+    </div>
+    <div class="project-card__meta">
+      ${tags.map((tag) => `<span>#${tag}</span>`).join('')}
+    </div>
+    <a class="project-card__link" href="${project.link}" target="_blank" rel="noopener">View project</a>
+  `;
+  return article;
+}
+
+function renderProjects(filter = activeProjectFilter) {
+  projectGrid.innerHTML = '';
+  const filtered =
+    filter === 'all' ? projectData : projectData.filter((project) => project.type === filter);
+
+  if (!filtered.length) {
+    projectGrid.innerHTML =
+      '<p>No projects found for this category yet. Add a new project JSON file to the data directory to feature it here.</p>';
+    return;
+  }
+
+  filtered.forEach((project) => {
+    projectGrid.appendChild(createProjectCard(project));
+  });
+}
+
+function createWhitePaperItem(paper) {
+  const article = document.createElement('article');
+  article.className = 'white-paper';
+  article.innerHTML = `
+    <h3>${paper.title}</h3>
+    <p>${paper.summary}</p>
+    <div class="white-paper__meta">
+      <span>${paper.authors}</span>
+      <span>${paper.year}</span>
+      <span>${paper.themes.join(', ')}</span>
+    </div>
+    <div class="white-paper__actions">
+      <a class="white-paper__link" href="${paper.link}" target="_blank" rel="noopener">Download PDF</a>
+    </div>
+  `;
+  return article;
+}
+
+function renderWhitePapers(term = '') {
+  whitePaperList.innerHTML = '';
+  if (!WHITE_PAPERS.length) {
+    whitePaperList.innerHTML =
+      '<p>White papers will be posted here as they become available.</p>';
+    return;
+  }
+  const normalized = term.trim().toLowerCase();
+
+  const filtered = WHITE_PAPERS.filter((paper) => {
+    const haystack = [paper.title, paper.summary, paper.authors, paper.themes.join(' ')].join(' ');
+    return haystack.toLowerCase().includes(normalized);
+  });
+
+  if (!filtered.length) {
+    whitePaperList.innerHTML = '<p>No white papers match your search. Try another keyword.</p>';
+    return;
+  }
+
+  filtered.forEach((paper) => {
+    whitePaperList.appendChild(createWhitePaperItem(paper));
+  });
+}
+
+function setActiveFilter(target) {
+  filterButtons.forEach((button) => button.classList.remove('is-active'));
+  target.classList.add('is-active');
+  activeProjectFilter = target.dataset.filter || 'all';
+}
+
+function toggleNavigation() {
+  const isOpen = navList.classList.toggle('is-open');
+  navToggle.setAttribute('aria-expanded', String(isOpen));
+}
+
+function closeNavigationOnLinkClick(event) {
+  if (event.target.tagName === 'A' && navList.classList.contains('is-open')) {
+    navList.classList.remove('is-open');
+    navToggle.setAttribute('aria-expanded', 'false');
+  }
+}
+
+async function loadProjectData() {
+  const projects = [];
+  let misses = 0;
+
+  for (let index = 1; index <= PROJECT_MAX_INDEX && misses < PROJECT_MAX_MISSES; index += 1) {
+    const paddedIndex = index.toString().padStart(2, '0');
+    const url = `${PROJECT_DATA_DIRECTORY}${PROJECT_FILENAME_PREFIX}${paddedIndex}${PROJECT_FILENAME_EXTENSION}`;
+
+    try {
+      const response = await fetch(url, { cache: 'no-store' });
+      if (!response.ok) {
+        misses += 1;
+        continue;
+      }
+
+      const data = await response.json();
+
+      if (data && data.title) {
+        projects.push(data);
+        misses = 0;
+      }
+    } catch (error) {
+      misses += 1;
+    }
+  }
+
+  return projects;
+}
+
+async function initializeProjects() {
+  if (!projectGrid) {
+    return;
+  }
+
+  projectGrid.innerHTML = '<p>Loading projects…</p>';
+  projectData = await loadProjectData();
+
+  if (!projectData.length) {
+    projectGrid.innerHTML =
+      '<p>No projects are published yet. Add JSON files to <code>assets/data/projects</code> to feature them here.</p>';
+    return;
+  }
+
+  renderProjects();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initializeProjects();
+  renderWhitePapers();
+
+  filterButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      setActiveFilter(button);
+      renderProjects(button.dataset.filter);
+    });
+  });
+
+  if (whitePaperSearch && WHITE_PAPERS.length) {
+    whitePaperSearch.addEventListener('input', (event) => {
+      renderWhitePapers(event.target.value);
+    });
+  } else if (whitePaperSearch) {
+    whitePaperSearch.setAttribute('disabled', 'true');
+    whitePaperSearch.setAttribute('aria-disabled', 'true');
+    whitePaperSearch.setAttribute('placeholder', 'White papers coming soon');
+  }
+
+  if (navToggle) {
+    navToggle.addEventListener('click', toggleNavigation);
+  }
+
+  if (navList) {
+    navList.addEventListener('click', closeNavigationOnLinkClick);
+  }
+
+  const form = document.querySelector('.form');
+  if (form) {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const emailField = form.querySelector('input[type="email"]');
+      if (emailField && emailField.value) {
+        form.reset();
+        const confirmation = document.createElement('p');
+        confirmation.className = 'form__confirmation';
+        confirmation.textContent = 'Thank you for subscribing! We will be in touch soon.';
+        form.appendChild(confirmation);
+        setTimeout(() => confirmation.remove(), 4000);
+      }
+    });
+  }
+
+  const yearElement = document.getElementById('copyright-year');
+  if (yearElement) {
+    yearElement.textContent = new Date().getFullYear();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,397 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Walter J. Ong, S.J. Center for Digital Humanities</title>
+    <meta
+      name="description"
+      content="Digital repository for the Walter J. Ong, S.J. Center for Digital Humanities at Saint Louis University, featuring research projects, resources, and white papers."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Source+Serif+4:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/main.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-inner">
+        <div class="brand">
+          <img src="assets/images/slu-shield.svg" alt="Saint Louis University shield" class="brand__mark" />
+          <div class="brand__text">
+            <span class="brand__label">Saint Louis University</span>
+            <span class="brand__unit">Walter J. Ong, S.J. Center for Digital Humanities</span>
+          </div>
+        </div>
+        <nav class="site-nav" aria-label="Primary">
+          <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-menu">
+            <span class="sr-only">Toggle navigation</span>
+            <span></span>
+            <span></span>
+            <span></span>
+          </button>
+          <ul id="primary-menu" class="site-nav__list">
+            <li><a href="#mission">About</a></li>
+            <li><a href="#legacy">Legacy</a></li>
+            <li><a href="#team">Team</a></li>
+            <li><a href="#affiliates">Faculty Affiliates</a></li>
+            <li><a href="#highlights">Impact</a></li>
+            <li><a href="#projects">Projects</a></li>
+            <li><a href="#white-papers">White Papers</a></li>
+            <li><a href="#resources">Resources</a></li>
+            <li><a href="#contact">Connect</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="container hero__content">
+          <div class="hero__text">
+            <p class="eyebrow">Digital Scholarship in the Jesuit Tradition</p>
+            <h1>Amplifying the humanities through collaborative, community-centered digital research.</h1>
+            <p>
+              The Ong Center for Digital Humanities connects faculty, students, and community partners to
+              advance scholarship, teaching, and outreach across Saint Louis University and beyond.
+            </p>
+            <div class="hero__actions">
+              <a class="button button--primary" href="#projects">Explore featured projects</a>
+              <a class="button button--ghost" href="#white-papers">Browse white papers</a>
+            </div>
+          </div>
+          <div class="hero__panel">
+            <h2 id="hero-highlights" class="hero__panel-title">Center highlights</h2>
+            <p class="hero__panel-text">
+              Saint Louis University&rsquo;s Ong Center stewards long-term platforms for digital scholarship and
+              collaborative research.
+            </p>
+            <ul class="hero__highlights" aria-labelledby="hero-highlights">
+              <li>
+                Infrastructure partner for <span>Rerum.io</span> and <span>T-PEN</span> to support interoperable
+                annotation and transcription work.
+              </li>
+              <li>
+                Collaborative digital editions such as <span>Sounding Tennyson</span> that blend research, audio, and
+                pedagogy.
+              </li>
+              <li>
+                Preservation initiatives including <span>Broken Books</span> that reunite dispersed manuscripts with
+                IIIF technology.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="mission" class="section section--light">
+        <div class="container section__grid">
+          <div>
+            <h2>Why the Ong Center?</h2>
+            <p class="lead">
+              We imagine new pathways for humanistic inquiry by pairing Jesuit values with cutting-edge
+              technologies and equitable collaboration.
+            </p>
+            <p>
+              From digitization and data storytelling to ethical AI and community archiving, the Ong Center serves
+              as a hub for interdisciplinary teams exploring the intersections of culture, technology, and social
+              justice. We provide strategic consultation, production support, and long-term stewardship for digital
+              projects at Saint Louis University.
+            </p>
+          </div>
+          <div class="card-stack">
+            <article class="card">
+              <h3>Build capacity</h3>
+              <p>
+                Workshops, consultations, and classroom partnerships equip SLU scholars with the tools and
+                mindsets needed for sustainable digital scholarship.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Incubate innovation</h3>
+              <p>
+                We mentor project teams from idea through implementation, offering design, development, and
+                assessment expertise.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Steward impact</h3>
+              <p>
+                Our repository preserves project legacies and documents methodologies to inspire future research
+                collaborations.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="legacy" class="section">
+        <div class="container section__grid section__grid--legacy">
+          <div>
+            <h2>Honoring Walter J. Ong, S.J.</h2>
+            <p class="lead">
+              The center bears the name of Jesuit scholar Walter J. Ong, whose groundbreaking work in rhetoric,
+              media ecology, and cultural history reshaped how we understand communication and knowledge in a digital
+              age.
+            </p>
+            <p>
+              Ong&rsquo;s lifelong commitment to bridging faith, scholarship, and public life continues to guide our
+              mission. His scholarship on oral and print cultures, Jesuit pedagogy, and the ethics of information
+              inspires the center to cultivate digital projects that are critically informed, community engaged, and
+              reflective of SLU&rsquo;s Jesuit heritage.
+            </p>
+            <p>
+              We celebrate Ong&rsquo;s legacy by mentoring the next generation of humanists and by sustaining projects
+              that foreground inclusive storytelling, accessible design, and rigorous inquiry.
+            </p>
+          </div>
+          <aside class="card legacy-highlight">
+            <h3>Ong Family Foundation support</h3>
+            <p>
+              The establishment of the center was made possible through generous seed funding from the Ong Family
+              Foundation. Their investment ensures that SLU scholars and partners have a permanent home for advancing
+              digital humanities research.
+            </p>
+            <p>
+              Continued philanthropic support helps us expand fellowships, preserve archival collections, and pilot
+              experimental collaborations that honor the spirit of Walter J. Ong, S.J.
+            </p>
+          </aside>
+        </div>
+      </section>
+
+      <section id="team" class="section section--light">
+        <div class="container">
+          <div class="section__header">
+            <h2>Our team</h2>
+            <p>
+              The Ong Center thrives because of a collaborative staff that integrates professional expertise with
+              student leadership across Saint Louis University.
+            </p>
+          </div>
+          <div class="people-groups">
+            <article class="people-group">
+              <h3>Center leadership &amp; staff</h3>
+              <p>
+                Directors, project managers, and technologists steward partnerships, guide research design, and
+                ensure long-term sustainability for every initiative we support.
+              </p>
+            </article>
+            <article class="people-group">
+              <h3>Graduate assistants</h3>
+              <p>
+                Master&rsquo;s and doctoral students contribute expertise in archival practice, data analysis, user
+                experience, and pedagogy while gaining mentorship in digital scholarship careers.
+              </p>
+            </article>
+            <article class="people-group">
+              <h3>Student collaborators</h3>
+              <p>
+                Undergraduate research assistants join faculty-led projects, develop new prototypes, and deliver
+                workshops that expand digital humanities skills across the SLU community.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="affiliates" class="section">
+        <div class="container">
+          <div class="section__header">
+            <h2>Faculty affiliates</h2>
+            <p>
+              Faculty members from across Saint Louis University collaborate with the Ong Center to co-design
+              research, integrate digital methods in the classroom, and mentor student teams.
+            </p>
+          </div>
+          <div class="affiliates-list">
+            <article>
+              <h3>College of Arts &amp; Sciences</h3>
+              <ul>
+                <li>English, Communication, and American Studies scholars advancing digital storytelling</li>
+                <li>Historians and archivists creating public-facing collections</li>
+                <li>Philosophy and theology faculty exploring ethics of emerging technologies</li>
+              </ul>
+            </article>
+            <article>
+              <h3>Libraries &amp; Museums</h3>
+              <ul>
+                <li>Curators and librarians supporting metadata strategy and preservation</li>
+                <li>Exhibit designers experimenting with immersive interpretation</li>
+              </ul>
+            </article>
+            <article>
+              <h3>Health Sciences &amp; Professional Programs</h3>
+              <ul>
+                <li>Public health and nursing faculty applying data storytelling to community outreach</li>
+                <li>Business and law partners focusing on digital ethics and policy</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="highlights" class="section section--accent">
+        <div class="container">
+          <div class="section__header">
+            <h2>Impact across disciplines</h2>
+            <p>
+              Through cross-campus partnerships, the Ong Center fosters work that advances the humanities, health
+              sciences, and community storytelling across the region.
+            </p>
+          </div>
+          <div class="impact-highlights">
+            <article class="impact-card">
+              <h3>Platform stewardship</h3>
+              <p>
+                Long-term hosting and development for digital ecosystems including Rerum.io and the transcription
+                environment T-PEN.
+              </p>
+            </article>
+            <article class="impact-card">
+              <h3>Research collaborations</h3>
+              <p>
+                Faculty, graduate, and undergraduate teams publish multimedia scholarship through projects like
+                Sounding Tennyson.
+              </p>
+            </article>
+            <article class="impact-card">
+              <h3>Preservation and access</h3>
+              <p>
+                Initiatives such as Broken Books reunite dispersed collections and document provenance with IIIF and
+                linked data services.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="projects" class="section">
+        <div class="container">
+          <div class="section__header section__header--split">
+            <div>
+              <h2>Featured digital humanities projects</h2>
+              <p>
+                Explore a curated selection of faculty- and student-led initiatives. Use the filters to focus on the
+                collaborations that best match your interests.
+              </p>
+            </div>
+            <div class="filters" role="group" aria-label="Filter projects">
+              <button class="filter-button is-active" data-filter="all">All</button>
+              <button class="filter-button" data-filter="faculty">Faculty</button>
+              <button class="filter-button" data-filter="student">Student</button>
+              <button class="filter-button" data-filter="community">Community Partnership</button>
+            </div>
+          </div>
+          <div class="project-grid" id="project-grid" aria-live="polite"></div>
+        </div>
+      </section>
+
+      <section id="white-papers" class="section section--light">
+        <div class="container">
+          <div class="section__header section__header--split">
+            <div>
+              <h2>Ong Center white papers</h2>
+              <p>
+                The white papers document methodologies, outcomes, and lessons learned from center-supported
+                initiatives. Files are hosted on SLU repositories for long-term preservation.
+              </p>
+            </div>
+            <div class="search">
+              <label for="white-paper-search" class="search__label">Search topics</label>
+              <input
+                id="white-paper-search"
+                class="search__input"
+                type="search"
+                placeholder="Search by title, author, or theme"
+                autocomplete="off"
+              />
+            </div>
+          </div>
+          <div id="white-paper-list" class="white-paper-list" aria-live="polite"></div>
+        </div>
+      </section>
+
+      <section id="resources" class="section">
+        <div class="container section__grid section__grid--resources">
+          <div>
+            <h2>Resources &amp; services</h2>
+            <ul class="checklist">
+              <li>Digital project strategy consultations</li>
+              <li>Humanities data design and visualization</li>
+              <li>Project management and grant development support</li>
+              <li>Digitization, metadata, and repository hosting</li>
+              <li>Ethical frameworks for community-engaged research</li>
+              <li>Workshops and curriculum partnerships</li>
+            </ul>
+          </div>
+          <div class="resource-card">
+            <h3>Planning a project?</h3>
+            <p>
+              Start with our project charter template and toolkit for building collaborative, sustainable initiatives.
+            </p>
+            <a class="button button--primary" href="#" aria-disabled="true">Download toolkit (coming soon)</a>
+            <p class="resource-card__note">Have an immediate need? Reach out and our team will follow up within two business days.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--accent section--cta">
+        <div class="container section__header section__header--cta">
+          <div>
+            <h2>Partner with the Ong Center</h2>
+            <p>
+              Let&rsquo;s imagine what&rsquo;s next for digital humanities at Saint Louis University. We welcome inquiries from
+              faculty, students, and community organizations.
+            </p>
+          </div>
+          <a class="button button--inverse" href="mailto:ongcenter@slu.edu">Start a conversation</a>
+        </div>
+      </section>
+    </main>
+
+    <footer id="contact" class="site-footer">
+      <div class="container site-footer__grid">
+        <div>
+          <h2 class="site-footer__title">Stay connected</h2>
+          <p>
+            Sign up for quarterly updates featuring project spotlights, funding opportunities, and invitations to
+            workshops.
+          </p>
+          <form class="form" aria-label="Newsletter sign-up">
+            <label class="sr-only" for="email">Email</label>
+            <input id="email" type="email" name="email" placeholder="Email address" required />
+            <button type="submit" class="button button--primary">Subscribe</button>
+          </form>
+        </div>
+        <div>
+          <h3>Visit us</h3>
+          <p>
+            Pius XII Memorial Library, Suite 213<br />
+            3650 Lindell Blvd<br />
+            St. Louis, MO 63108
+          </p>
+          <p class="contact-links">
+            <a href="mailto:ongcenter@slu.edu">ongcenter@slu.edu</a><br />
+            <a href="tel:+13149779400">314-977-9400</a>
+          </p>
+        </div>
+        <div>
+          <h3>Explore our projects</h3>
+          <ul class="social-links">
+            <li><a href="https://rerum.io/">Rerum.io</a></li>
+            <li><a href="https://t-pen.org/TPEN/">T-PEN</a></li>
+            <li><a href="https://soundingtennyson.org/">Sounding Tennyson</a></li>
+            <li><a href="https://brokenbooks.slu.edu/">Broken Books</a></li>
+          </ul>
+          <p class="footer-note">© <span id="copyright-year"></span> Saint Louis University. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+
+    <script src="assets/js/app.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- load featured project cards from JSON files dropped into `assets/data/projects`
- add data files for Rerum.io, T-PEN, Sounding Tennyson, and Broken Books while removing fabricated listings
- refresh hero highlights, impact copy, and footer links to focus on documented Ong Center work and guidance for contributors

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d448701998832da3ec39fdd85804c6